### PR TITLE
Add timezone and pagination controls to admin booking table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/public/admin-settings.html
+++ b/public/admin-settings.html
@@ -34,7 +34,12 @@
     </div>
     <div id="loginStatus" style="color:#b00;margin-top:8px;"></div>
   </div>
-  <div id="app" class="hidden"><div class="card" style="display:flex;justify-content:space-between;align-items:center;"><div><button id="logoutBtn">Logout</button></div><div id="rightActions"><a href="/admin.html" style="text-decoration:none;font-size:14px;">← Back to Dashboard</a></div></div><div class="card">
+  <div id="app" class="hidden">
+    <div class="card" style="display:flex;justify-content:space-between;align-items:center;">
+      <div><button id="logoutBtn">Logout</button></div>
+      <div id="rightActions"><a href="/admin.html" style="text-decoration:none;font-size:14px;">← Back to Dashboard</a></div>
+    </div>
+    <div class="card">
       <h2>Display Settings</h2>
       <div class="row">
         <label for="timezoneSelect">Time Zone:</label>
@@ -46,9 +51,10 @@
         </select>
         <label for="pageSizeSetting">Bookings per page:</label>
         <input id="pageSizeSetting" type="number" min="1" value="20" style="width:60px;">
-        <button id="saveSettingsBtn">Save Settings</button>
+        <button id="saveSettingsBtn" type="button">Save Settings</button>
       </div>
-    </div><div class="card">
+    </div>
+    <div class="card">
       <h2>Spaces</h2>
       <div class="row">
         <input id="spaceName" placeholder="Name">
@@ -179,17 +185,17 @@
     }
 
     function loadDisplaySettings() {
-      const tzSel = document.getElementById('timezoneSelect');
-      if (tzSel) tzSel.value = localStorage.getItem('adminTimezone') || 'UTC';
-      const pageInput = document.getElementById('pageSizeSetting');
-      if (pageInput) pageInput.value = localStorage.getItem('bookingsPageSize') || '20';
+      const tz = document.getElementById('timezoneSelect');
+      if (tz) tz.value = localStorage.getItem('adminTimezone') || 'UTC';
+      const page = document.getElementById('pageSizeSetting');
+      if (page) page.value = localStorage.getItem('bookingsPageSize') || '20';
     }
 
     function saveDisplaySettings() {
-      const tzSel = document.getElementById('timezoneSelect');
-      const pageInput = document.getElementById('pageSizeSetting');
-      if (tzSel) localStorage.setItem('adminTimezone', tzSel.value);
-      if (pageInput) localStorage.setItem('bookingsPageSize', pageInput.value || '20');
+      const tz = document.getElementById('timezoneSelect');
+      const page = document.getElementById('pageSizeSetting');
+      if (tz) localStorage.setItem('adminTimezone', tz.value);
+      if (page) localStorage.setItem('bookingsPageSize', page.value || '20');
       alert('Settings saved');
     }
 
@@ -241,8 +247,7 @@
           document.getElementById('app').classList.remove('hidden');
           updateSettingsLinkIfNeeded();
           ensureSuperAdminIfNeeded();
-          updateSettingsLinkIfNeeded();
-          ensureSuperAdminIfNeeded();
+          loadDisplaySettings();
           await refreshAll();
         } else {
           if (res.status === 401) status.textContent = data.error || 'Invalid credentials';
@@ -818,7 +823,6 @@
     document.addEventListener('DOMContentLoaded', () => {
       updateSettingsLinkIfNeeded();
       ensureSuperAdminIfNeeded();
-      loadDisplaySettings();
       // Safe bindings
       (function(){
         function on(id, event, handler){
@@ -834,23 +838,14 @@
         on('loadAnalyticsBtn','click', loadAnalytics);
         on('loadSummaryBtn','click', loadSummary);
         on('downloadCsvBtn','click', downloadCsv);
+        on('saveSettingsBtn', 'click', saveDisplaySettings);
       })();
 
       updateSettingsLinkIfNeeded();
       ensureSuperAdminIfNeeded();
-      on('loginBtn','click', login);
-      on('logoutBtn','click', logout);
-      on('addSpaceBtn','click', addSpace);
-      on('addAdminBtn','click', addAdmin);
-      on('generateKioskBtn','click', generateKioskToken);
-      on('addBookingBtn','click', addBooking);
-      on('loadAnalyticsBtn','click', loadAnalytics);
-      on('loadSummaryBtn','click', loadSummary);
-      on('downloadCsvBtn','click', downloadCsv);
-      on('saveSettingsBtn','click', saveDisplaySettings);
-
-      // Global error banner
-      window.addEventListener('error', (e) => {
+      loadDisplaySettings();
+        // Global error banner
+        window.addEventListener('error', (e) => {
         const div = document.getElementById('loginStatus');
         if (div && !div.textContent) {
           div.textContent = 'Script error: ' + (e.message || e.error || 'Unknown error');

--- a/public/admin-settings.html
+++ b/public/admin-settings.html
@@ -35,6 +35,20 @@
     <div id="loginStatus" style="color:#b00;margin-top:8px;"></div>
   </div>
   <div id="app" class="hidden"><div class="card" style="display:flex;justify-content:space-between;align-items:center;"><div><button id="logoutBtn">Logout</button></div><div id="rightActions"><a href="/admin.html" style="text-decoration:none;font-size:14px;">← Back to Dashboard</a></div></div><div class="card">
+      <h2>Display Settings</h2>
+      <div class="row">
+        <label for="timezoneSelect">Time Zone:</label>
+        <select id="timezoneSelect">
+          <option value="UTC">UTC</option>
+          <option value="America/New_York">America/New_York</option>
+          <option value="Europe/London">Europe/London</option>
+          <option value="Asia/Tokyo">Asia/Tokyo</option>
+        </select>
+        <label for="pageSizeSetting">Bookings per page:</label>
+        <input id="pageSizeSetting" type="number" min="1" value="20" style="width:60px;">
+        <button id="saveSettingsBtn">Save Settings</button>
+      </div>
+    </div><div class="card">
       <h2>Spaces</h2>
       <div class="row">
         <input id="spaceName" placeholder="Name">
@@ -162,6 +176,21 @@
       opts.headers = opts.headers || {};
       opts.headers['Authorization'] = 'Bearer ' + token;
       return opts;
+    }
+
+    function loadDisplaySettings() {
+      const tzSel = document.getElementById('timezoneSelect');
+      if (tzSel) tzSel.value = localStorage.getItem('adminTimezone') || 'UTC';
+      const pageInput = document.getElementById('pageSizeSetting');
+      if (pageInput) pageInput.value = localStorage.getItem('bookingsPageSize') || '20';
+    }
+
+    function saveDisplaySettings() {
+      const tzSel = document.getElementById('timezoneSelect');
+      const pageInput = document.getElementById('pageSizeSetting');
+      if (tzSel) localStorage.setItem('adminTimezone', tzSel.value);
+      if (pageInput) localStorage.setItem('bookingsPageSize', pageInput.value || '20');
+      alert('Settings saved');
     }
 
     // Logout helper for the settings page. Without defining a logout
@@ -789,6 +818,7 @@
     document.addEventListener('DOMContentLoaded', () => {
       updateSettingsLinkIfNeeded();
       ensureSuperAdminIfNeeded();
+      loadDisplaySettings();
       // Safe bindings
       (function(){
         function on(id, event, handler){
@@ -817,6 +847,7 @@
       on('loadAnalyticsBtn','click', loadAnalytics);
       on('loadSummaryBtn','click', loadSummary);
       on('downloadCsvBtn','click', downloadCsv);
+      on('saveSettingsBtn','click', saveDisplaySettings);
 
       // Global error banner
       window.addEventListener('error', (e) => {

--- a/public/admin.html
+++ b/public/admin.html
@@ -90,7 +90,13 @@
       </div>
       <div class="row" style="justify-content: space-between; align-items: center; margin: 8px 0;">
         <!-- Update heading to reflect that we now load all bookings (not just upcoming) -->
-        <div><strong>Bookings</strong></div>
+        <div>
+          <strong>Bookings</strong>
+          <input id="bookingFilter" placeholder="Filter" style="margin-left:8px;">
+          <label style="margin-left:8px;font-weight:normal;">
+            <input type="checkbox" id="showPast"> Show past
+          </label>
+        </div>
         <div>
           <button id="prevPageBtn">&lt; Prev</button>
           <span id="pageInfo" style="margin:0 8px;"></span>
@@ -99,7 +105,16 @@
       </div>
       <table id="bookingsTable">
         <thead>
-          <tr><th>Name</th><th>Email</th><th>Space</th><th>Date</th><th>Start</th><th>End</th><th>Recurring</th><th>Action</th></tr>
+          <tr>
+            <th data-sort="name">Name</th>
+            <th data-sort="email">Email</th>
+            <th data-sort="spaceName">Space</th>
+            <th data-sort="date">Date</th>
+            <th data-sort="startTime">Start</th>
+            <th data-sort="endTime">End</th>
+            <th data-sort="recurring">Recurring</th>
+            <th>Action</th>
+          </tr>
         </thead>
         <tbody></tbody>
       </table>
@@ -539,36 +554,79 @@
       await loadSpaces();
     }
 
-    async function loadBookings() {
-      if (!window._pageState) window._pageState = { offset: 0, limit: 50, total: 0 };
-      const { offset, limit } = window._pageState;
-      // Fetch all bookings from the server.
-      return fetch('/api/bookings', setAuthHeaders())
-        .then(r => r.json())
-        .then(data => {
-          const items = Array.isArray(data) ? data : (data.items || []);
-          items.sort((a, b) => {
-            const dateA = a.date || '';
-            const dateB = b.date || '';
-            const cmpDate = dateB.localeCompare(dateA);
-            if (cmpDate !== 0) return cmpDate;
-            const startA = a.startTime || '';
-            const startB = b.startTime || '';
-            return (startB || '').localeCompare(startA || '');
-          });
-          const total = items.length;
-          window._pageState.total = total;
+      let _bookingsData = [];
+      let _bookingsFilter = '';
+      let _bookingsSort = { key: 'date', dir: -1 };
+      let _pageState = { page: 1, pageSize: parseInt(localStorage.getItem('bookingsPageSize'), 10) || 20 };
+      let _showPast = false;
 
-          const tbody = document.querySelector('#bookingsTable tbody');
+      function nowInSelectedTimezone() {
+        const tz = localStorage.getItem('adminTimezone') || Intl.DateTimeFormat().resolvedOptions().timeZone;
+        try {
+          const str = new Date().toLocaleString('sv-SE', { timeZone: tz });
+          return new Date(str.replace(' ', 'T'));
+        } catch (e) {
+          return new Date();
+        }
+      }
+
+      function isUpcoming(b) {
+        const now = nowInSelectedTimezone();
+        const today = now.toISOString().slice(0,10);
+        const cur = now.toISOString().slice(11,16);
+        if (b.date > today) return true;
+        if (b.date === today && (b.endTime || '00:00') >= cur) return true;
+        return false;
+      }
+
+      async function refreshBookings() {
+        try {
+          const res = await fetch('/api/bookings', setAuthHeaders());
+          const data = await res.json();
+          _bookingsData = Array.isArray(data) ? data : (data.items || []);
+          renderBookingsTable();
+        } catch (e) {
+          console.error('refreshBookings error', e);
+        }
+      }
+
+      function renderBookingsTable() {
+        let items = _bookingsData.slice();
+        if (!_showPast) {
+          items = items.filter(isUpcoming);
+        }
+        if (_bookingsFilter) {
+          const f = _bookingsFilter.toLowerCase();
+          items = items.filter(b =>
+            (b.name || '').toLowerCase().includes(f) ||
+            (b.email || '').toLowerCase().includes(f) ||
+            (b.spaceName || '').toLowerCase().includes(f)
+          );
+        }
+
+        items.sort((a, b) => {
+          let va = a[_bookingsSort.key] || '';
+          let vb = b[_bookingsSort.key] || '';
+          return _bookingsSort.dir * va.localeCompare(vb);
+        });
+
+        const total = items.length;
+        const maxPage = Math.max(1, Math.ceil(total / _pageState.pageSize));
+        if (_pageState.page > maxPage) _pageState.page = maxPage;
+        const startIdx = (_pageState.page - 1) * _pageState.pageSize;
+        const pageItems = items.slice(startIdx, startIdx + _pageState.pageSize);
+
+        const tbody = document.querySelector('#bookingsTable tbody');
+        if (tbody) {
           tbody.innerHTML = '';
-          items.forEach(b => {
+          pageItems.forEach(b => {
             const tr = document.createElement('tr');
             const start12 = to12Hour(b.startTime);
             const end12 = to12Hour(b.endTime);
             const dateFormatted = formatDateWithDay(b.date);
             const recurrenceDesc = formatRecurrence(b.recurrence);
-            tr.innerHTML = 
-`<td>${b.name}</td><td>${b.email}</td><td>${b.spaceName}</td>` +
+            tr.innerHTML =
+              `<td>${b.name}</td><td>${b.email}</td><td>${b.spaceName}</td>` +
               `<td>${dateFormatted}</td>` +
               `<td>${start12}</td>` +
               `<td>${end12}</td>` +
@@ -576,15 +634,70 @@
               `<td><button data-id="${b.id}" class="delBooking">Cancel</button></td>`;
             tbody.appendChild(tr);
           });
+        }
 
-          const start = total === 0 ? 0 : 1;
-          const end = total;
-          document.getElementById('pageInfo').textContent = `${start}-${end} of ${total}`;
+        const start = total === 0 ? 0 : (startIdx + 1);
+        const end = Math.min(startIdx + pageItems.length, total);
+        const pageInfo = document.getElementById('pageInfo');
+        if (pageInfo) pageInfo.textContent = `${start}-${end} of ${total}`;
 
-          document.getElementById('prevPageBtn').disabled = true;
-          document.getElementById('nextPageBtn').disabled = true;
+        const prev = document.getElementById('prevPageBtn');
+        const next = document.getElementById('nextPageBtn');
+        if (prev) prev.disabled = _pageState.page <= 1;
+        if (next) next.disabled = _pageState.page >= maxPage;
+      }
+
+      async function loadBookings() {
+        await refreshBookings();
+        if (window._bookingsInterval) clearInterval(window._bookingsInterval);
+        window._bookingsInterval = setInterval(refreshBookings, 30000);
+      }
+
+      function initDynamicBookings() {
+        const filter = document.getElementById('bookingFilter');
+        if (filter) {
+          filter.addEventListener('input', (e) => {
+            _bookingsFilter = e.target.value;
+            renderBookingsTable();
+          });
+        }
+        const pastToggle = document.getElementById('showPast');
+        if (pastToggle) {
+          pastToggle.addEventListener('change', (e) => {
+            _showPast = e.target.checked;
+            _pageState.page = 1;
+            renderBookingsTable();
+          });
+        }
+        document.querySelectorAll('#bookingsTable th[data-sort]').forEach(th => {
+          th.style.cursor = 'pointer';
+          th.addEventListener('click', () => {
+            const key = th.dataset.sort;
+            if (_bookingsSort.key === key) {
+              _bookingsSort.dir *= -1;
+            } else {
+              _bookingsSort = { key, dir: 1 };
+            }
+            renderBookingsTable();
+          });
         });
-    }
+        const prev = document.getElementById('prevPageBtn');
+        const next = document.getElementById('nextPageBtn');
+        if (prev) {
+          prev.addEventListener('click', () => {
+            if (_pageState.page > 1) {
+              _pageState.page--;
+              renderBookingsTable();
+            }
+          });
+        }
+        if (next) {
+          next.addEventListener('click', () => {
+            _pageState.page++;
+            renderBookingsTable();
+          });
+        }
+      }
 
     // NEW: proper async addBooking implementation (fixes stray awaits)
     async function addBooking() {
@@ -632,7 +745,7 @@
           // Note: Auto bookings are anonymous endpoints and do not require admin auth
           const autoRes = await fetch('/api/bookings/auto?' + params.toString());
           if (autoRes.ok) {
-            if (window._pageState) window._pageState.offset = 0;
+            if (window._pageState) window._pageState.page = 1;
             // Wait briefly to allow data persistence and then reload the bookings
             await new Promise(resolve => setTimeout(resolve, 200));
             await loadBookings();
@@ -657,7 +770,7 @@
         }));
 
         if (res.ok) {
-          if (window._pageState) window._pageState.offset = 0;
+          if (window._pageState) window._pageState.page = 1;
           await new Promise(resolve => setTimeout(resolve, 200));
           await loadBookings();
           // show confirmation and clear inputs
@@ -934,9 +1047,10 @@
     }
 
     // One-time DOM wiring
-    document.addEventListener('DOMContentLoaded', () => {
-      updateSettingsLinkIfNeeded();
-      ensureSuperAdminIfNeeded();
+      document.addEventListener('DOMContentLoaded', () => {
+        updateSettingsLinkIfNeeded();
+        ensureSuperAdminIfNeeded();
+        initDynamicBookings();
       // Safe bindings
       (function(){
         function on(id, event, handler){
@@ -978,26 +1092,6 @@
           div.textContent = 'Script error: ' + (e.message || e.error || 'Unknown error');
         }
       });
-
-      // Pagination
-      const prevBtn = document.getElementById('prevPageBtn');
-      const nextBtn = document.getElementById('nextPageBtn');
-      if (prevBtn && nextBtn) {
-        prevBtn.addEventListener('click', () => {
-          if (!window._pageState) window._pageState = { offset: 0, limit: 50, total: 0 };
-          const ps = window._pageState;
-          ps.offset = Math.max(0, ps.offset - ps.limit);
-          loadBookings();
-        });
-        nextBtn.addEventListener('click', () => {
-          if (!window._pageState) window._pageState = { offset: 0, limit: 50, total: 0 };
-          const ps = window._pageState;
-          if (ps.offset + ps.limit < ps.total) {
-            ps.offset = ps.offset + ps.limit;
-            loadBookings();
-          }
-        });
-      }
 
       // Auto-show app if token already present
       if (token) {


### PR DESCRIPTION
## Summary
- Allow super admins to set timezone and bookings-per-page in new display settings card
- Default admin booking table to upcoming entries, with toggle for past and pagination using saved page size

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68baee346230832785e790b8e904880b