### PR TITLE
Add date and time filtering to admin bookings

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -595,11 +595,22 @@
         let items = _bookingsData.slice();
         if (_bookingsFilter) {
           const f = _bookingsFilter.toLowerCase();
-          items = items.filter(b =>
-            (b.name || '').toLowerCase().includes(f) ||
-            (b.email || '').toLowerCase().includes(f) ||
-            (b.spaceName || '').toLowerCase().includes(f)
-          );
+          items = items.filter(b => {
+            const dateStr = formatDateWithDay(b.date).toLowerCase();
+            const start12 = to12Hour(b.startTime).toLowerCase();
+            const end12 = to12Hour(b.endTime).toLowerCase();
+            return (
+              (b.name || '').toLowerCase().includes(f) ||
+              (b.email || '').toLowerCase().includes(f) ||
+              (b.spaceName || '').toLowerCase().includes(f) ||
+              (b.date || '').toLowerCase().includes(f) ||
+              dateStr.includes(f) ||
+              (b.startTime || '').toLowerCase().includes(f) ||
+              (b.endTime || '').toLowerCase().includes(f) ||
+              start12.includes(f) ||
+              end12.includes(f)
+            );
+          });
         }
 
         if (!_showPastBookings) {


### PR DESCRIPTION
## Summary
- allow admins to search bookings by date and time in the bookings table

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68bef7abb3ac8327a782ba540f858efa