### PR TITLE
Include recurring bookings in upcoming admin view

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -618,6 +618,10 @@
           items = items.filter(b => {
             if (b.date > now.date) return true;
             if (b.date === now.date && (b.endTime || '00:00') >= now.time) return true;
+            // Recurring bookings may have a start date in the past but still
+            // represent future occurrences. Treat them as upcoming so they
+            // remain visible in the table even when past bookings are hidden.
+            if (b.recurring || b.recurrence) return true;
             return false;
           });
         }


### PR DESCRIPTION
## Summary
- ensure recurring bookings appear when filtering out past bookings on the admin page

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_68bf3d87d2388327ad2ef65366447bd1