### PR TITLE
Reconstruct check-in flag from timestamp

### DIFF
--- a/server.js
+++ b/server.js
@@ -404,6 +404,7 @@ async function loadData() {
         recurring: r.recurring || null,
         checkInTime: r.checkInTime || null,
         checkOutTime: r.checkOutTime || null,
+        checkedIn: !!r.checkInTime,
         cancelled: r.cancelled || false
       })));
       // Load admins from the database
@@ -2138,7 +2139,7 @@ app.get('/api/analytics-export', adminAuth, (req, res) => {
         spaceName,
         b.startTime,
         b.endTime,
-        b.checkedIn ? 'Yes' : 'No'
+        b.checkInTime ? 'Yes' : 'No'
       ];
       rows.push(row.map(escapeCsv).join(','));
     }


### PR DESCRIPTION
## Summary
- Restore in-memory `checkedIn` flag when loading bookings from the database using the persisted `checkInTime`
- Ensure CSV export derives checked-in status from `checkInTime` for accuracy

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68c6fd5f262c8327aa17f5ff4732a413